### PR TITLE
Configurable retry on failure flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,15 @@ error: ENVKEY invalid
 ### Flags
 
 ```text
-    --cache              cache encrypted config as a local backup (default is false)
-    --cache-dir string   cache directory (default is $HOME/.envkey/cache)
--h, --help               help for envkey-fetch
--v, --version            prints the version
-    --verbose            print verbose output (default is false)
-    --timeout float      timeout in seconds for http requests (default 2)
+    --cache                   cache encrypted config as a local backup (default is false)
+    --cache-dir string        cache directory (default is $HOME/.envkey/cache)
+    --client-name string      calling client library name (default is none)
+    --client-version string   calling client library version (default is none)
+-h, --help                    help for envkey-fetch
+    --retry int               retry on failure
+    --timeout float           timeout in seconds for http requests (default 10)
+    --verbose                 print verbose output (default is false)
+-v, --version                 prints the version
 ```
 
 ## Further Reading

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ var verboseOutput bool
 var clientName string
 var clientVersion string
 var timeoutSeconds float64
+var retry int64
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -49,7 +50,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		if len(args) > 0 {
-			res, err := fetch.Fetch(args[0], fetch.FetchOptions{shouldCache, cacheDir, clientName, clientVersion, verboseOutput, timeoutSeconds})
+			res, err := fetch.Fetch(args[0], fetch.FetchOptions{shouldCache, cacheDir, clientName, clientVersion, verboseOutput, timeoutSeconds, retry})
 			if err != nil {
 				fmt.Fprintln(os.Stderr, "error: "+err.Error())
 				os.Exit(1)
@@ -79,4 +80,5 @@ func init() {
 	RootCmd.Flags().BoolVarP(&printVersion, "version", "v", false, "prints the version")
 	RootCmd.Flags().BoolVar(&verboseOutput, "verbose", false, "print verbose output (default is false)")
 	RootCmd.Flags().Float64Var(&timeoutSeconds, "timeout", 10.0, "timeout in seconds for http requests")
+	RootCmd.Flags().Int64Var(&retry, "retry", 0, "retry on failure")
 }

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -90,7 +90,7 @@ func Fetch(envkey string, options FetchOptions) (string, error) {
 			fmt.Fprintln(os.Stderr, err)
 		}
 
-		if options.Retry > 1 {
+		if options.Retry > 0 {
 			options.Retry--
 			return Fetch(envkey, options)
 		}

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -29,6 +29,7 @@ type FetchOptions struct {
 	ClientVersion  string
 	VerboseOutput  bool
 	TimeoutSeconds float64
+	Retry          int64
 }
 
 var DefaultHost = "env.envkey.com"
@@ -87,6 +88,11 @@ func Fetch(envkey string, options FetchOptions) (string, error) {
 		if options.VerboseOutput {
 			fmt.Fprintln(os.Stderr, "Error parsing and decrypting:")
 			fmt.Fprintln(os.Stderr, err)
+		}
+
+		if options.Retry > 1 {
+			options.Retry--
+			return Fetch(envkey, options)
 		}
 
 		if fetchCache != nil {

--- a/fetch/fetch_test/fetch_test.go
+++ b/fetch/fetch_test/fetch_test.go
@@ -104,7 +104,7 @@ func TestFetch(t *testing.T) {
 
 			fetch.Fetch(test.envkey, opts)
 			if test.expectErr && test.responseStatus != http.StatusNotFound {
-				assert.Equal(retry, callCount, test.desc+" should retry")
+				assert.Equal(retry+1, callCount, test.desc+" should retry")
 			} else {
 				assert.Equal(1, callCount, test.desc+" should not retry")
 			}


### PR DESCRIPTION
adds a flag to configure how many retries to attempt when the initial call fails. 
defaults to `0` which will maintain the previous functionality.